### PR TITLE
Update Dave2DDriver to v2.0.1

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -38,9 +38,9 @@
             "command": [
                 "cpackget init https://www.keil.com/pack/index.pidx;",
                 "cpackget add https://github.com/ARM-software/CMSIS_6/releases/download/v6.0.0/ARM.CMSIS.6.0.0.pack;",
-                "cpackget add https://github.com/alifsemi/alif_ensemble-cmsis-dfp/releases/download/v1.3.3/AlifSemiconductor.Ensemble.1.3.3.pack;",
-                "cpackget add https://github.com/alifsemi/alif_dave2d-driver/releases/download/v2.0.0/AlifSemiconductor.Dave2DDriver.2.0.0.pack;",
-                "cpackget add https://github.com/alifsemi/alif_image-processing-lib/releases/download/v1.0.0/AlifSemiconductor.AIPL.1.0.1.pack;",
+                "cpackget add https://github.com/alifsemi/alif_ensemble-cmsis-dfp/releases/download/v2.0.2/AlifSemiconductor.Ensemble.2.0.2.pack;",
+                "cpackget add https://github.com/alifsemi/alif_dave2d-driver/releases/download/v2.0.1/AlifSemiconductor.Dave2DDriver.2.0.1.pack;",
+                "cpackget add https://github.com/alifsemi/alif_image-processing-lib/releases/download/v1.3.0/AlifSemiconductor.AIPL.1.3.0.pack;",
                 "cpackget list;",
                 "echo 'Pack installation has been completed'"
             ],

--- a/alif.cbuild-pack.yml
+++ b/alif.cbuild-pack.yml
@@ -6,12 +6,9 @@ cbuild-pack:
     - resolved-pack: AlifSemiconductor::AIPL@1.3.0
       selected-by-pack:
         - AlifSemiconductor::AIPL@1.3.0
-    - resolved-pack: AlifSemiconductor::Dave2DDriver@1.0.1
+    - resolved-pack: AlifSemiconductor::Dave2DDriver@2.0.1
       selected-by-pack:
-        - AlifSemiconductor::Dave2DDriver@1.0.1
-    - resolved-pack: AlifSemiconductor::Dave2DDriver@2.0.0
-      selected-by-pack:
-        - AlifSemiconductor::Dave2DDriver@2.0.0
+        - AlifSemiconductor::Dave2DDriver@2.0.1
     - resolved-pack: AlifSemiconductor::Ensemble@2.0.2
       selected-by-pack:
         - AlifSemiconductor::Ensemble@2.0.2

--- a/alif.csolution.yml
+++ b/alif.csolution.yml
@@ -12,7 +12,7 @@ solution:
 
   packs:
     - pack: AlifSemiconductor::Ensemble@2.0.2
-    - pack: AlifSemiconductor::Dave2DDriver@2.0.0
+    - pack: AlifSemiconductor::Dave2DDriver@2.0.1
     - pack: ARM::CMSIS@6.0.0
     - pack: AlifSemiconductor::AIPL@1.3.0
 


### PR DESCRIPTION
Adds Dave2DDriver support for E4, E6, E1C and B1 devices. 

Also fix 1st time pack installation versions