### PR TITLE
Use 40FPS for ARX3A0 for better image quality

### DIFF
--- a/viewfinder/RTE/Device/AE822FA0E5597LS0_M55_HE/RTE_Device.h
+++ b/viewfinder/RTE/Device/AE822FA0E5597LS0_M55_HE/RTE_Device.h
@@ -505,7 +505,7 @@
 //     <90=> 90 FPS
 // <i> Defines camera ARX3A0 frame per second
 // <i> Default: 90 FPS
-#define RTE_ARX3A0_CAMERA_SENSOR_CSI_CFG_FPS                 90
+#define RTE_ARX3A0_CAMERA_SENSOR_CSI_CFG_FPS                 40
 
 // <o> Select camera ARX3A0 frequency
 // <i> Defines camera ARX3A0 frequency

--- a/viewfinder/camera/camera.c
+++ b/viewfinder/camera/camera.c
@@ -91,7 +91,7 @@ int camera_init(void) {
     // NOTE: There is automatic gain control implemented for ARX3A0 in ML example repository
     //       https://github.com/alifsemi/alif_ml-embedded-evaluation-kit
 #if defined(RTE_Drivers_CAMERA_SENSOR_ARX3A0)
-    CAMERAdrv->Control(CPI_CAMERA_SENSOR_GAIN, 0x10000 * 5.0f);
+    CAMERAdrv->Control(CPI_CAMERA_SENSOR_GAIN, 0x10000 * 2.0f);
 #endif
 
     return ret;


### PR DESCRIPTION
- Additionally, lowered the default manual gain setting